### PR TITLE
Remove libraries dependency and add cloudinary_php as composer dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 # Created by .ignore support plugin (hsz.mobi)
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "drupal/cloudinary",
+    "description": "The module provides image transformation of Cloudinary, auto convert default image style effects with Cloudinary transformation.",
+    "type": "drupal-module",
+    "license": "GPL-2.0+",
+    "minimum-stability": "dev",
+    "homepage": "https://drupal.org/project/cloudinary",
+    "support": {
+        "issues": "https://drupal.org/project/issues/cloudinary",
+        "source": "http://cgit.drupalcode.org/cloudinary"
+    },
+    "require": {
+        "cloudinary/cloudinary_php": "^1.8"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,70 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "84da8115f3576d78df8c9fcd9c15fd5d",
+    "packages": [
+        {
+            "name": "cloudinary/cloudinary_php",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary/cloudinary_php.git",
+                "reference": "641b0901ca616c540b773abb802987a502aa8b89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/cloudinary_php/zipball/641b0901ca616c540b773abb802987a502aa8b89",
+                "reference": "641b0901ca616c540b773abb802987a502aa8b89",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ],
+                "files": [
+                    "src/Helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/cloudinary_php/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP SDK",
+            "homepage": "https://github.com/cloudinary/cloudinary_php",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "time": "2017-05-03T14:29:33+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/modules/cloudinary_sdk/cloudinary_sdk.info.yml
+++ b/modules/cloudinary_sdk/cloudinary_sdk.info.yml
@@ -2,7 +2,4 @@ name: 'Cloudinary SDK'
 description: 'The module provides a library of Cloudinary PHP SDK for developers working with Cloudinary service.'
 package: Cloudinary
 core: 8.x
-dependencies:
-  - 'libraries (>= 2.0)'
-php: '5.3'
 type: module

--- a/modules/cloudinary_sdk/cloudinary_sdk.module
+++ b/modules/cloudinary_sdk/cloudinary_sdk.module
@@ -27,51 +27,6 @@ define('CLOUDINARY_SDK_OLD_VERSION', 1);
 define('CLOUDINARY_SDK_LOADED', 2);
 
 /**
- * Implements hook_libraries_info().
- */
-function cloudinary_sdk_libraries_info() {
-  return array(
-    'cloudinary' => array(
-      'name' => 'Cloudinary SDK for PHP',
-      'vendor url' => 'http://cloudinary.com/',
-      'download url' => 'https://github.com/cloudinary/cloudinary_php',
-      'path' => 'src',
-      'version arguments' => array(
-        'file' => '/vendor/cloudinary/cloudinary_php/src/Cloudinary.php',
-        'pattern' => '/const VERSION = "(.*)";/',
-        'lines' => 13,
-      ),
-      'files' => array(
-        'php' => array(
-          'Cloudinary.php',
-          'Uploader.php',
-          'Api.php',
-        ),
-      ),
-      'callbacks' => array(
-        // Initialize cloudinary sdk after the library is loaded.
-        'post-load' => array(
-          'cloudinary_sdk_callback',
-        ),
-      ),
-    ),
-  );
-}
-
-/**
- * Initialize cloudinary sdk after the library is loaded.
- */
-function cloudinary_sdk_callback(&$library, $version = NULL, $variant = NULL) {
-  $initialized = &drupal_static(__FUNCTION__, FALSE);
-
-  if ($initialized !== TRUE) {
-    $initialized = cloudinary_sdk_init();
-  }
-
-  return $initialized;
-}
-
-/**
  * Cloudinary configuration initialization.
  */
 function cloudinary_sdk_init($config = array()) {

--- a/modules/cloudinary_stream_wrapper/src/StreamWrapper/CloudinaryStreamWrapper.php
+++ b/modules/cloudinary_stream_wrapper/src/StreamWrapper/CloudinaryStreamWrapper.php
@@ -102,9 +102,6 @@ class CloudinaryStreamWrapper implements StreamWrapperInterface {
    * Load Cloudinary PHP SDK & initialize Cloudinary configuration.
    */
   public function __construct() {
-    // Load Cloudinary PHP SDK.
-    libraries_load('cloudinary');
-
     // Check whether folder creation is enabled.
     $config = \Drupal::config('cloudinary_sdk.settings');
     $this->autoCreateFolder = $config->get('cloudinary_stream_wrapper_enable_api_folder_creation', FALSE);


### PR DESCRIPTION
Now, cloudinary_php is loaded with the `libraries` module. However, in Drupal 8 we can use Composer for external libraries. The `libraries` module isn't needed anymore.